### PR TITLE
Small workflow to refresh upload portal backend data

### DIFF
--- a/.github/workflows/ProcessInfoFile.yml
+++ b/.github/workflows/ProcessInfoFile.yml
@@ -48,5 +48,6 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           cwd: BilayerData
-          add: "Simulations/* UserData/*.yml"
+          add: '["Simulations/**/*.yaml", "Simulations/**/*.json"]'
+          remove: UserData/*.yml
           message: "Processed info file and updated simulations"

--- a/.github/workflows/RefreshGithubGateway.yml
+++ b/.github/workflows/RefreshGithubGateway.yml
@@ -1,0 +1,22 @@
+name: Refresh Upload Portal Data
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Molecules/**'
+
+  workflow_dispatch:
+
+jobs:
+  refresh-upload-portal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hit refresh endpoint
+        id: refresh
+        run: |
+            curl --silent --show-error --fail-with-body \
+              -X POST \
+              -H "Authorization: Bearer ${{ secrets.UPLOAD_PORTAL_REFRESH_TOKEN }}" \
+              https://upload-portal.nmrlipids.fi/api/refresh-databank-files 


### PR DESCRIPTION
- Minor change to addition of simulation files via the upload portal to fix bug
- Small workflow that hits endpoint for refreshing the upload portal backend resources when new molecule data is added (mapping files, molecule names)
- Uses very minimal read only token which can live for years without worry