### PR TITLE
Minor PR fixing name check for one workflow

### DIFF
--- a/.github/workflows/ProcessInfoFile.yml
+++ b/.github/workflows/ProcessInfoFile.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Add, commit and push changes 
         working-directory: BilayerData
         run: |
-          git config user.name "simulation-addition-helper[bot]"
-          git config user.email "simulation-addition-helper[bot]@users.noreply.github.com"
+          git config user.name "simulation-addition-admin[bot]"
+          git config user.email "simulation-addition-admin[bot]@users.noreply.github.com"
           TOKEN='${{ steps.app-token.outputs.token }}'
           REPO='${{ github.event.pull_request.head.repo.full_name }}'
           git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${REPO}.git"

--- a/.github/workflows/RunGlobalAnalysis.yml
+++ b/.github/workflows/RunGlobalAnalysis.yml
@@ -17,7 +17,7 @@ jobs:
   Run_Analysis: 
     if: github.event_name == 'workflow_dispatch' ||   
       (github.event.pull_request.merged &&
-      github.event.pull_request.head.repo.full_name == 'MagnusSletten/BilayerData'  &&
+      github.event.pull_request.head.repo.full_name == 'NMRLipids/UserData'  &&
       github.repository == 'NMRLipids/BilayerData')
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Also updates bot name. 
There are now two bots, one designated to userdata repo with higher permissions to handle edge cases where workflow updates require elevated permissions for repo synchronization. 