### PR TITLE
Fix issue with negative IDs in CheckID script

### DIFF
--- a/.github/workflows/CheckIDs.sh
+++ b/.github/workflows/CheckIDs.sh
@@ -58,9 +58,9 @@ else
  fixlist=()
  unique_ids=()
 
- # Repeated IDs
+ # Repeated IDs, excluding negatives IDs
  if [[ ${#duplicates[@]} -ne 0 ]]; then
-  unique_ids=($( printf "%s\n" "${duplicates[@]}" | sort -u ))
+  unique_ids=($( printf "%s\n" "${duplicates[@]}" | awk '$1>=0' | sort -u ))
  fi
 
  # No ID assigned


### PR DESCRIPTION
Checks for any negative IDs present and outputs info to github actions step summary following the same flow as the rest of the script. 

Example of PR created [here](https://github.com/MagnusSletten/BilayerData/pull/12), output of action [here](https://github.com/MagnusSletten/BilayerData/actions/runs/16961390303)

Closes #46 