### PR TITLE
Add workflows to validate molecule data and info files

### DIFF
--- a/.github/workflows/ProcessInfoFile.yml
+++ b/.github/workflows/ProcessInfoFile.yml
@@ -19,7 +19,6 @@ jobs:
       options: --user 1000:1000
     env:
       NMLDB_DATA_PATH: ${{ github.workspace }}/BilayerData
-      NMLDB_SIMU_PATH: ${{ github.workspace }}/BilayerData/Simulations
       MEM_CUTOFF: 1500000000
     steps:
       - name: Checkout BilayerData

--- a/.github/workflows/ProcessInfoFile.yml
+++ b/.github/workflows/ProcessInfoFile.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       NMLDB_DATA_PATH: ${{ github.workspace }}/BilayerData
       NMLDB_SIMU_PATH: ${{ github.workspace }}/BilayerData/Simulations
+      MEM_CUTOFF: 1500000000
     steps:
       - name: Checkout BilayerData
         uses: actions/checkout@v4

--- a/.github/workflows/ValidateInfoFile.yml
+++ b/.github/workflows/ValidateInfoFile.yml
@@ -1,0 +1,43 @@
+name: Validate info file
+permissions:
+  contents: read
+
+on:
+  pull_request_target:
+    types: [opened]
+    paths:
+      - 'UserData/**'
+jobs:
+  ValidateInfoFile:
+    if: "${{ github.event.pull_request.head.repo.full_name == 'NMRlipids/UserData' && github.repository == 'NMRlipids/BilayerData' }}"
+    runs-on: ubuntu-latest
+    container:
+      image: nmrlipids/core
+      options: --user 1001:118
+    env:
+      NMLDB_DATA_PATH: ${{ github.workspace }}/BilayerData
+      NMLDB_SIMU_PATH: ${{ github.workspace }}/BilayerData/Simulations
+    steps:
+      - name: Checkout BilayerData
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          path: BilayerData
+          persist-credentials: false
+
+      - name: Checkout Databank
+        uses: actions/checkout@v4
+        with:
+          repository: NMRlipids/Databank
+          ref: main
+          path: Databank
+
+      - name: Run dry run of AddData 
+        env:
+          TQDM_DISABLE: True
+        working-directory: Databank
+        run: |
+          pip install -e . -r ./Scripts/DatabankLib/requirements.txt
+          python Scripts/WorkflowScripts/ProcessInfoFile.py \
+            --info_file_path ../BilayerData/UserData/info.yml --dry-run

--- a/.github/workflows/ValidateInfoFile.yml
+++ b/.github/workflows/ValidateInfoFile.yml
@@ -13,10 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: nmrlipids/core
-      options: --user 1001:118
+      options: --user 1001:118 # run container as uid=1001,gid=118 to match the GitHub runner user
     env:
       NMLDB_DATA_PATH: ${{ github.workspace }}/BilayerData
-      NMLDB_SIMU_PATH: ${{ github.workspace }}/BilayerData/Simulations
     steps:
       - name: Checkout BilayerData
         uses: actions/checkout@v4

--- a/.github/workflows/ValidateMolecules.yml
+++ b/.github/workflows/ValidateMolecules.yml
@@ -1,0 +1,43 @@
+name: Validate Molecules
+permissions:
+  contents: read
+
+on: 
+  pull_request_target: 
+      branches: main
+      paths: Molecules/**
+jobs: 
+    Validate_Databank:
+        if: github.repository == 'NMRLipids/BilayerData' 
+        runs-on: ubuntu-latest
+        container:
+            image: nmrlipids/core
+            options: --user 1001:118
+        env:
+            NMLDB_DATA_PATH: ${{ github.workspace }}/BilayerData
+            NMLDB_SIMU_PATH: ${{ github.workspace }}/BilayerData/Simulations
+        steps:
+          - name: Checkout BilayerData
+            uses: actions/checkout@v4
+            with:
+                repository: ${{ github.event.pull_request.head.repo.full_name }}
+                ref: ${{ github.event.pull_request.head.ref }}
+                path: BilayerData
+
+          - name: Checkout Databank
+            uses: actions/checkout@v4
+            with:
+                repository: NMRlipids/Databank
+                ref: main
+                path: Databank
+            
+          - name: Install Databank dependencies
+            working-directory: "Databank"
+            run: |
+               pip install -e . -r ./Scripts/DatabankLib/requirements.txt
+
+          - name: Validate
+            working-directory: "Databank"
+            run: |
+              python Scripts/WorkflowScripts/ValidateData.py
+

--- a/.github/workflows/ValidateMolecules.yml
+++ b/.github/workflows/ValidateMolecules.yml
@@ -12,10 +12,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: nmrlipids/core
-            options: --user 1001:118
+            options: --user 1001:118 # run container as uid=1001,gid=118 to match the GitHub runner user
         env:
             NMLDB_DATA_PATH: ${{ github.workspace }}/BilayerData
-            NMLDB_SIMU_PATH: ${{ github.workspace }}/BilayerData/Simulations
         steps:
           - name: Checkout BilayerData
             uses: actions/checkout@v4


### PR DESCRIPTION
* Adds workflow to validate info files which is run using normal github runners
  * Closes #79 
* Set memory cutoff at 1.5GB using environmental variable 
  * Closes https://github.com/NMRLipids/UploadPortal/issues/12 
  * Technically setting the environmental variable here does not change behaviour as 1.5GB is the default, but having it in the workflowfile makes it easy to change later if this is needed. 
* Add workflow to verify that new data containing changes to molecules does not cause problems for the Databank
  * Closes https://github.com/NMRLipids/Databank/issues/334