### PR TITLE
Use strict mode for run_analysis in sim workflow

### DIFF
--- a/.github/workflows/ProcessInfoFile.yml
+++ b/.github/workflows/ProcessInfoFile.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Compute new data
         env:
           TQDM_DISABLE: True
+          NML_STRICT_MODE: True
         working-directory: Databank
         run: |
           pip install .


### PR DESCRIPTION
This PR just sets the env variable in the workflow for processing info files. 