### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 1
+    groups:
+      action-dependencies:
+        patterns:
+          - "*" # A wildcard to create one PR for all dependencies in the ecosystem
+          


### PR DESCRIPTION
This PR adds a Dependabot configuration file so it can create PRs for dependency updates.

Closes #131