### PR TITLE
Closing/reopening sim addition PR will retrigger addition workflow

### DIFF
--- a/.github/workflows/ProcessInfoFile.yml
+++ b/.github/workflows/ProcessInfoFile.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, reopened]
     paths:
       - 'UserData/**'
 jobs:


### PR DESCRIPTION
If we make changes to the sim addition workflow we can now close/reopen PRs to make sure they use the latest version of the workflow. 

Closes #155 