### PR TITLE
OP dataset publication

### DIFF
--- a/.github/workflows/CheckExperimentSchema.yml
+++ b/.github/workflows/CheckExperimentSchema.yml
@@ -19,7 +19,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           path: BilayerData
-          
+
       - name: Checkout Databank
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/PublishDatasets.yml
+++ b/.github/workflows/PublishDatasets.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           set -e
           pip install .
+          echo "DATABANK_ROOT=${PWD}" >> $GITHUB_ENV
           pip install kaggle unidecode tables
 
       - name: Prepare dataset metadata
@@ -69,7 +70,7 @@ jobs:
         run: |
           set -e
           cd dataset
-          python developer/gen-op-dataset.py --sims
+          python ${DATABANK_ROOT}/developer/gen-op-dataset.py --sims
           cd ..
           kaggle datasets version -p ./dataset -m "Dataset auto-release from ${SHORT_SHA}"
 

--- a/.github/workflows/PublishDatasets.yml
+++ b/.github/workflows/PublishDatasets.yml
@@ -4,15 +4,33 @@ permissions:
    contents: read
 
 on:
-  # TODO: add on-release
   workflow_dispatch:
-  pull_request:
+    inputs:
+      dataset:
+        description: 'Dataset to generate and publish'
+        required: true
+        type: choice
+        options:
+          - op-sim
+          - op-exp
 
 jobs:
-  gen_op_exp_dataset:
-    # TODO: activate in the production pipeline
-    # if: github.repository == 'NMRLipids/BilayerData'
+  gen_op_dataseta:
+    if: github.repository == 'NMRLipids/BilayerData'
     runs-on: ubuntu-latest
+    env:
+      SCRIPT_ARGS: >-
+        ${{
+          inputs.dataset == 'op-sim' && '--sims' ||
+          inputs.dataset == 'op-exp' && '--exps' ||
+          '--other'
+        }}
+      SLUG_NAME: >-
+        ${{
+          inputs.dataset == 'op-sim' && 'lipid-ch-order-parameters-from-md-simulations' ||
+          inputs.dataset == 'op-exp' && 'lipid-ch-order-parameters-from-experiments' ||
+          '--other'
+        }}
     steps:
       - name: Checkout BilayerData
         uses: actions/checkout@v6
@@ -22,8 +40,8 @@ jobs:
       - name: Checkout Databank API
         uses: actions/checkout@v6
         with:
-          repository: comcon1/Databank
-          ref: datasets-geenerator
+          repository: NMRlipids/FAIRMD_lipids
+          ref: datasets-geenerator # TODO: turn off when merged to main
           path: Databank
 
       - name: Pin python version
@@ -48,7 +66,7 @@ jobs:
           set -e
           mkdir dataset
           cd dataset
-          kaggle datasets metadata fairmd/lipid-ch-order-parameters-from-md-simulations
+          kaggle datasets metadata fairmd/${SLUG_NAME}
           jq '{
             id: .info.datasetSlug,
             id_no: .info.datasetId,

--- a/.github/workflows/PublishDatasets.yml
+++ b/.github/workflows/PublishDatasets.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Checkout Databank API
         uses: actions/checkout@v6
         with:
-          repository: NMRLipids/FAIRMD_lipids
-          ref: datasets-generator
+          repository: comcon1/Databank
+          ref: datasets-geenerator
           path: Databank
 
       - name: Pin python version

--- a/.github/workflows/PublishDatasets.yml
+++ b/.github/workflows/PublishDatasets.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   # TODO: add on-release
   workflow_dispatch:
+  pull_request:
 
 jobs:
   gen_op_exp_dataset:

--- a/.github/workflows/PublishDatasets.yml
+++ b/.github/workflows/PublishDatasets.yml
@@ -1,0 +1,63 @@
+name: Generate and publish Kaggle Datasets
+
+permissions:
+   contents: read
+
+on:
+  # TODO: add on-release
+  workflow_dispatch:
+
+jobs:
+  gen_op_exp_dataset:
+    # TODO: activate in the production pipeline
+    # if: github.repository == 'NMRLipids/BilayerData'
+    runs-on: ubuntu-latest
+    container:
+      image: nmrlipids/core
+      options: --user 1001:118
+    env:
+      FMDL_DATA_PATH: ${{ github.workspace }}/BilayerData
+    steps:
+      - name: Checkout BilayerData
+        uses: actions/checkout@v6
+        with:
+          path: BilayerData
+
+      - name: Checkout Databank API
+        uses: actions/checkout@v6
+        with:
+          repository: NMRLipids/FAIRMD_lipids
+          ref: datasets-generator
+          path: Databank
+
+      - name: Compute OP dataset
+        env:
+          TQDM_DISABLE: "True"
+        working-directory: "Databank"
+        run: |
+          pip install .
+          python developer/gen-op-dataset.py --exps
+      
+      # TODO: debug it
+      - name: Upload Result Dataset to Kaggle
+      env:
+          KAGGLE_USERNAME: ${{ secrets.KAGGLE_USER }}
+          KAGGLE_KEY: ${{ secrets.KAGGLE_TOKEN }}
+      working-directory: "Databank"
+      run: |
+          pip install kaggle --quiet
+  
+          # Create the metadata file for the dataset
+          cat > dataset-metadata.json << EOF
+          {
+          "title": "NMRLipids FAIRMD Lipids Databank",
+          "id": "${{ secrets.KAGGLE_USER }}/fairmd-lipids-databank",
+          "licenses": [{ "name": "CC0-1.0" }]
+          }
+          EOF
+  
+          # Create new dataset or push a new version if it already exists
+          kaggle datasets create -p . --dir-mode zip || \
+          kaggle datasets version -p . -m "Automated update from CI - ${{ github.sha }}" --dir-mode zip
+
+

--- a/.github/workflows/PublishDatasets.yml
+++ b/.github/workflows/PublishDatasets.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Prepare dataset metadata
         env:
           TQDM_DISABLE: "True"
-          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_TOKEN }}
+          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_KEY }}
         working-directory: "BilayerData"
         run: |
           set -e
@@ -63,7 +63,7 @@ jobs:
       - name: Prepare new data
         env:
           TQDM_DISABLE: "True"
-          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_TOKEN }}
+          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_KEY }}
           FMDL_DATA_PATH: ${{ github.workspace }}/BilayerData
         working-directory: "BilayerData"
         run: |

--- a/.github/workflows/PublishDatasets.yml
+++ b/.github/workflows/PublishDatasets.yml
@@ -1,4 +1,4 @@
-name: Generate and publish Kaggle Datasets
+name: Generate and publish Kaggle Dataset
 
 permissions:
    contents: read
@@ -12,11 +12,6 @@ jobs:
     # TODO: activate in the production pipeline
     # if: github.repository == 'NMRLipids/BilayerData'
     runs-on: ubuntu-latest
-    container:
-      image: nmrlipids/core
-      options: --user 1001:118
-    env:
-      FMDL_DATA_PATH: ${{ github.workspace }}/BilayerData
     steps:
       - name: Checkout BilayerData
         uses: actions/checkout@v6
@@ -30,34 +25,50 @@ jobs:
           ref: datasets-generator
           path: Databank
 
-      - name: Compute OP dataset
-        env:
-          TQDM_DISABLE: "True"
+      - name: Pin python version
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Databank API, Kaggle API
         working-directory: "Databank"
         run: |
+          set -e
           pip install .
-          python developer/gen-op-dataset.py --exps
-      
-      # TODO: debug it
-      - name: Upload Result Dataset to Kaggle
-      env:
-          KAGGLE_USERNAME: ${{ secrets.KAGGLE_USER }}
-          KAGGLE_KEY: ${{ secrets.KAGGLE_TOKEN }}
-      working-directory: "Databank"
-      run: |
-          pip install kaggle --quiet
-  
-          # Create the metadata file for the dataset
-          cat > dataset-metadata.json << EOF
-          {
-          "title": "NMRLipids FAIRMD Lipids Databank",
-          "id": "${{ secrets.KAGGLE_USER }}/fairmd-lipids-databank",
-          "licenses": [{ "name": "CC0-1.0" }]
-          }
-          EOF
-  
-          # Create new dataset or push a new version if it already exists
-          kaggle datasets create -p . --dir-mode zip || \
-          kaggle datasets version -p . -m "Automated update from CI - ${{ github.sha }}" --dir-mode zip
+          pip install kaggle unidecode tables
 
+      - name: Prepare dataset metadata
+        env:
+          TQDM_DISABLE: "True"
+          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_TOKEN }}
+        working-directory: "BilayerData"
+        run: |
+          set -e
+          mkdir dataset
+          cd dataset
+          kaggle datasets metadata fairmd/lipid-ch-order-parameters-from-md-simulations
+          jq '{
+            id: .info.datasetSlug,
+            id_no: .info.datasetId,
+            title: .info.datasetSlug,
+            subtitle: (.info.subtitle // ""),
+            description: (.info.description // "")
+          }' dataset-metadata.json > tmp.json
+          mv tmp.json dataset-metadata.json
+
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+      - name: Prepare new data
+        env:
+          TQDM_DISABLE: "True"
+          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_TOKEN }}
+          FMDL_DATA_PATH: ${{ github.workspace }}/BilayerData
+        working-directory: "BilayerData"
+        run: |
+          set -e
+          cd dataset
+          python developer/gen-op-dataset.py --sims
+          cd ..
+          kaggle datasets version -p ./dataset -m "Dataset auto-release from ${SHORT_SHA}"
 

--- a/.github/workflows/PublishDatasets.yml
+++ b/.github/workflows/PublishDatasets.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           set -e
           cd dataset
-          python ${DATABANK_ROOT}/developer/gen-op-dataset.py --sims
+          python ${DATABANK_ROOT}/developer/gen-op-dataset.py ${SCRIPT_ARGS}
           cd ..
           kaggle datasets version -p ./dataset -m "Dataset auto-release from ${SHORT_SHA}"
 

--- a/.github/workflows/PublishDatasets.yml
+++ b/.github/workflows/PublishDatasets.yml
@@ -72,7 +72,8 @@ jobs:
             id_no: .info.datasetId,
             title: .info.datasetSlug,
             subtitle: (.info.subtitle // ""),
-            description: (.info.description // "")
+            description: (.info.description // ""),
+            keywords: .info.keywords
           }' dataset-metadata.json > tmp.json
           mv tmp.json dataset-metadata.json
 


### PR DESCRIPTION
Automatic dataset publication to NMRlipids Kaggle account.

It requires dataset-creating script to be in place. For that we have this PR: https://github.com/NMRLipids/FAIRMD_lipids/pull/491 
However, you can test it even without that one being merged because it refers currently to the branch. I tested it on my branch. But you need a KAGGLE secret to test it.

You can check my repo:  https://github.com/comcon1/BilayerData/actions/runs/24932009452 this is a link to sucessfull run.

Also, the dataset with a defined slug must be already created. We only push the version. First dataset we must publish by ourselves. I think it's meaningful because we need to fill a lot of fields when we do so.